### PR TITLE
chore: remove `pretest` command from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc",
-    "pretest": "yarn build",
     "test": "mocha --timeout 60000 -r ts-node/register 'src/*.test.ts'"
   },
   "engines": {


### PR DESCRIPTION
No need for this command. Remove it.