### PR TITLE
feat: add ability to export coin data via JSON and/or CSV with new `--save` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
   "dependencies": {
     "@crypto-coffee/coingecko-api": "^1.1.0",
     "chalk": "4.1.2",
+    "json2csv": "^5.0.7",
     "meow": "9"
   },
   "devDependencies": {
     "@types/chai": "^4.3.1",
+    "@types/json2csv": "^5.0.3",
     "@types/mocha": "^9.1.1",
     "@types/node": "^18.6.4",
     "chai": "^4.3.6",

--- a/src/actions/saveCoinData.ts
+++ b/src/actions/saveCoinData.ts
@@ -1,9 +1,13 @@
 import type { ExportData } from '../app';
 import { logError, logSuccess } from '../utils';
-import { CSVEXT, JSONCSVEXT, JSONEXT } from '../constants';
+import { CSVEXT, JSONEXT } from '../constants';
+import { parseAsync } from 'json2csv';
 import fs from 'fs';
 
-export const saveCoinData = (options: string, exportData: ExportData[]) => {
+export const saveCoinData = async (
+  options: string,
+  exportData: ExportData[]
+) => {
   const fileExts = options.toLowerCase().split(',');
 
   if (
@@ -18,29 +22,25 @@ export const saveCoinData = (options: string, exportData: ExportData[]) => {
   }
 
   logSuccess('Exporting coin data...');
-  switch (fileExts.toString()) {
-    case JSONEXT:
-      writeFile(exportData, JSONEXT);
-      break;
-    case CSVEXT:
-      writeFile(exportData, CSVEXT);
-      break;
-    case JSONCSVEXT:
-      writeFile(exportData, JSONCSVEXT);
-      break;
-    default:
+  if (fileExts.includes(JSONEXT)) {
+    writeFile(exportData, JSONEXT);
   }
+
+  if (fileExts.includes(CSVEXT)) {
+    await writeFile(exportData, CSVEXT);
+  }
+
+  logSuccess('Export complete.');
 };
 
-const writeFile = (exportData: ExportData[], fileExt: string) => {
-  const timestamp = new Date().toISOString().substring(0, 10);
+const writeFile = async (exportData: ExportData[], fileExt: string) => {
   for (const coin of exportData) {
+    const data =
+      fileExt === JSONEXT ? JSON.stringify(coin) : await formatCsvFile(coin);
     try {
-      fs.writeFileSync(
-        `${(coin.name as string).toLowerCase()}-${timestamp}.${fileExt}`,
-        JSON.stringify(coin),
-        { encoding: 'utf8' }
-      );
+      fs.writeFileSync(formatFileName(coin.name as string, fileExt), data, {
+        encoding: 'utf8'
+      });
     } catch (error) {
       logError(
         `An error occured when attempting to save coin data: \n ${
@@ -49,5 +49,52 @@ const writeFile = (exportData: ExportData[], fileExt: string) => {
       );
     }
   }
-  logSuccess('Export complete.');
+};
+
+const formatFileName = (coinName: string, fileExt: string): string => {
+  /* use unix timestamp, resolves conflict of same filenames */
+  const timestamp = new Date().valueOf();
+
+  return `${coinName.toLowerCase()}-${timestamp}.${fileExt}`;
+};
+
+const formatCsvFile = async (coin: ExportData): Promise<string> => {
+  return await parseAsync(coin as Readonly<ExportData>, {
+    delimiter: ',',
+    excelStrings: false,
+    fields: [
+      {
+        label: 'Name',
+        value: 'name'
+      },
+      {
+        label: 'Current Price',
+        value: 'current_price'
+      },
+      {
+        label: 'Total Volume',
+        value: 'total_volume'
+      },
+      {
+        label: 'High 24H',
+        value: 'high_24h'
+      },
+      {
+        label: 'Low 24H',
+        value: 'low_24h'
+      },
+      {
+        label: 'Price Change Percentage 24H',
+        value: 'price_change_percentage_24h'
+      },
+      {
+        label: 'All Time High',
+        value: 'all_time_high'
+      },
+      {
+        label: 'All Time High Percentage',
+        value: 'ath_change_percentage'
+      }
+    ]
+  });
 };

--- a/src/actions/saveCoinData.ts
+++ b/src/actions/saveCoinData.ts
@@ -1,0 +1,51 @@
+import type { ExportData } from '../app';
+import { logError, logSuccess } from '../utils';
+import { CSVEXT, JSONCSVEXT, JSONEXT } from '../constants';
+import fs from 'fs';
+
+export const saveCoinData = (options: string, exportData: ExportData[]) => {
+  const fileExts = options.toLowerCase().split(',');
+
+  if (
+    !fileExts.some(
+      fileExt =>
+        fileExt.toLowerCase() === JSONEXT || fileExt.toLowerCase() === CSVEXT
+    )
+  ) {
+    logError('Unknown file type. Check `crypto --help` for help');
+  }
+
+  logSuccess('Exporting coin data...');
+  switch (fileExts.toString()) {
+    case JSONEXT:
+      writeFile(exportData, JSONEXT);
+      break;
+    case CSVEXT:
+      writeFile(exportData, CSVEXT);
+      break;
+    case JSONCSVEXT:
+      writeFile(exportData, JSONCSVEXT);
+      break;
+    default:
+  }
+};
+
+const writeFile = (exportData: ExportData[], fileExt: string) => {
+  const timestamp = new Date().toISOString().substring(0, 10);
+  for (const coin of exportData) {
+    try {
+      fs.writeFileSync(
+        `${coin.name}-${timestamp}.${fileExt}`,
+        JSON.stringify(coin),
+        { encoding: 'utf8' }
+      );
+    } catch (error) {
+      logError(
+        `An error occured when attempting to save coin data: \n ${
+          (error as Error).message
+        }`
+      );
+    }
+  }
+  logSuccess('Export complete.');
+};

--- a/src/actions/saveCoinData.ts
+++ b/src/actions/saveCoinData.ts
@@ -12,7 +12,9 @@ export const saveCoinData = (options: string, exportData: ExportData[]) => {
         fileExt.toLowerCase() === JSONEXT || fileExt.toLowerCase() === CSVEXT
     )
   ) {
-    logError('Unknown file type. Check `crypto --help` for help');
+    logError(
+      'Unable to export, unsupported file extension.\nPlease Check `crypto --help` for help'
+    );
   }
 
   logSuccess('Exporting coin data...');
@@ -35,7 +37,7 @@ const writeFile = (exportData: ExportData[], fileExt: string) => {
   for (const coin of exportData) {
     try {
       fs.writeFileSync(
-        `${coin.name}-${timestamp}.${fileExt}`,
+        `${(coin.name as string).toLowerCase()}-${timestamp}.${fileExt}`,
         JSON.stringify(coin),
         { encoding: 'utf8' }
       );

--- a/src/app.ts
+++ b/src/app.ts
@@ -133,7 +133,7 @@ export const app = async (action: string, flags: Record<string, unknown>) => {
     }
 
     if (save) {
-      saveCoinData(save, exportCoinData);
+      await saveCoinData(save, exportCoinData);
     }
 
     process.exit(0);

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,8 @@
 import CoinGeckoAPI from '@crypto-coffee/coingecko-api';
+import { saveCoinData } from './actions/saveCoinData';
 import { logError, logSuccess, format } from './utils';
+
+export type ExportData = Record<string, string | number>;
 
 interface Flags {
   price: string[];
@@ -9,6 +12,7 @@ interface Flags {
   low: boolean;
   ath: boolean;
   athChange: boolean;
+  save: string;
 }
 
 interface CoinMarketResponse {
@@ -41,7 +45,7 @@ interface CoinMarketResponse {
 }
 
 export const app = async (action: string, flags: Record<string, unknown>) => {
-  const { price, priceChange, volume, high, low, ath, athChange } =
+  const { price, priceChange, volume, high, low, ath, athChange, save } =
     flags as unknown as Flags;
 
   if (!price.length) {
@@ -59,6 +63,7 @@ export const app = async (action: string, flags: Record<string, unknown>) => {
       logError(`Unknown coin: ${price.toString()}`);
     }
 
+    const exportCoinData: ExportData[] = [];
     for (const {
       name,
       current_price,
@@ -101,6 +106,17 @@ export const app = async (action: string, flags: Record<string, unknown>) => {
         athChangeRes = `ATH (%): ${athPercent.toFixed(2)}%`;
       }
 
+      exportCoinData.push({
+        name,
+        current_price,
+        total_volume,
+        high_24h,
+        low_24h,
+        price_change_percentage_24h: percent24h,
+        all_time_high: athPrice,
+        ath_change_percentage: athPercent
+      });
+
       logSuccess(
         [
           priceRes,
@@ -115,6 +131,12 @@ export const app = async (action: string, flags: Record<string, unknown>) => {
           .join(' - ')
       );
     }
+
+    if (save) {
+      saveCoinData(save, exportCoinData);
+    }
+
+    process.exit(0);
   } catch (error) {
     logError(
       `An error occured: ${

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,2 @@
 export const JSONEXT = 'json';
 export const CSVEXT = 'csv';
-export const JSONCSVEXT = `${JSONEXT},${CSVEXT}`;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,3 @@
+export const JSONEXT = 'json';
+export const CSVEXT = 'csv';
+export const JSONCSVEXT = `${JSONEXT},${CSVEXT}`;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -30,7 +30,7 @@ describe('crypto-cli', () => {
       describe('with a valid coin name', () => {
         it('returns the price', async () => {
           const results = await execa(CLI, ['--price', 'bitcoin']);
-       
+
           /* price will vary this output is always returned if successful */
           assert.include(results.stdout, 'Bitcoin: $');
           assert.equal(results.exitCode, 0);
@@ -169,6 +169,40 @@ describe('crypto-cli', () => {
 
           assert.include(results.stdout, 'Bitcoin: $');
           assert.include(results.stdout, 'ATH (%):');
+          assert.equal(results.exitCode, 0);
+        });
+      });
+    });
+
+    describe('with `--save`', () => {
+      describe('give format csv', () => {
+        it('returns the price', async () => {
+          const results = await execa(CLI, [
+            '--price',
+            'bitcoin',
+            '--save',
+            'csv'
+          ]);
+
+          assert.include(results.stdout, 'Bitcoin: $');
+          assert.include(results.stdout, 'Exporting coin data...');
+          assert.include(results.stdout, 'Export complete.');
+          assert.equal(results.exitCode, 0);
+        });
+      });
+
+      describe('give format json', () => {
+        it('returns the price', async () => {
+          const results = await execa(CLI, [
+            '--price',
+            'bitcoin',
+            '--save',
+            'json'
+          ]);
+
+          assert.include(results.stdout, 'Bitcoin: $');
+          assert.include(results.stdout, 'Exporting coin data...');
+          assert.include(results.stdout, 'Export complete.');
           assert.equal(results.exitCode, 0);
         });
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,10 +17,15 @@ const cli = meow(
   --ath - coin all time high price
   --athChange, --athc - percent price change from ATH
   --version - current version of the crypto-cli tool
+  --save - export all coin data to CSV and/or JSON
 
   Examples:
   $crypto --price bitcoin --pc
   >> bitoin: $1337 - change (24H): 13.37%
+
+  Save coin data:
+  $crypto --save json 
+  $crypto --save json,csv
 `,
   {
     flags: {
@@ -49,6 +54,9 @@ const cli = meow(
       athChange: {
         type: 'boolean',
         alias: 'athc'
+      },
+      save: {
+        type: 'string'
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,6 +81,13 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.1.tgz#e2c6e73e0bdeb2521d00756d099218e9f5d90a04"
   integrity sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==
 
+"@types/json2csv@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@types/json2csv/-/json2csv-5.0.3.tgz#759514772a90e35b08c10808dedeaf52248af418"
+  integrity sha512-ZJEv6SzhPhgpBpxZU4n/TZekbZqI4EcyXXRwms1lAITG2kIAtj85PfNYafUOY1zy8bWs5ujaub0GU4copaA0sw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/minimist@^1.2.0":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
@@ -90,6 +97,11 @@
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.1.1.tgz#e7c4f1001eefa4b8afbd1eee27a237fee3bf29c4"
   integrity sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==
+
+"@types/node@*":
+  version "18.7.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.3.tgz#432c89796eab539b7a30b7b8801a727b585238a4"
+  integrity sha512-LJgzOEwWuMTBxHzgBR/fhhBOWrvBjvO+zPteUgbbuQi80rYIZHrk1mNbRUqPZqSLP2H7Rwt1EFLL/tNLD1Xx/w==
 
 "@types/node@^18.6.4":
   version "18.6.4"
@@ -313,6 +325,11 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+commander@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -666,6 +683,20 @@ json-parse-even-better-errors@^2.3.0:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
+json2csv@^5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/json2csv/-/json2csv-5.0.7.tgz#f3a583c25abd9804be873e495d1e65ad8d1b54ae"
+  integrity sha512-YRZbUnyaJZLZUJSRi2G/MqahCyRv9n/ds+4oIetjDF3jWQA7AG7iSeKTiZiCNqtMZM7HDyt0e/W6lEnoGEmMGA==
+  dependencies:
+    commander "^6.1.0"
+    jsonparse "^1.3.1"
+    lodash.get "^4.4.2"
+
+jsonparse@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
+  integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
+
 kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
@@ -689,6 +720,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
 log-symbols@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
This PR introduces a new flag `--save` which allows the user to export the coin data via JSON and CSV. 

It also supports multiple coins, it will create new JSON/CSV for each coin passed to the CLI. 

Example: 

```sh
crypto --p bitcoin --save json
```
This command will create a new JSON file: `bitcoin-timestamp.json`

Or, 

```sh
crypto --p bitcoin  --p ethereum --save json
```
This command will create a two new JSON files: `bitcoin-timestamp` and `ethereum-timestamp`

Closes issue: https://github.com/Zidious/crypto-cli/issues/29