### PR TITLE
refactor: breakout functionality code from `app.ts` into `src/actions`

### DIFF
--- a/src/actions/priceStats.ts
+++ b/src/actions/priceStats.ts
@@ -1,0 +1,67 @@
+import { format, logSuccess } from '../utils';
+import type { Flags } from '../constants';
+
+interface PriceStatsParams {
+  name: string;
+  current_price: number;
+  total_volume: number;
+  high_24h: number;
+  low_24h: number;
+  percent24h: number;
+  athPrice: number;
+  athPercent: number;
+}
+
+type PriceStatFlags = Omit<Flags, 'save'>;
+
+export const priceStats = (
+  {
+    name,
+    current_price,
+    total_volume,
+    high_24h,
+    low_24h,
+    percent24h,
+    athPrice,
+    athPercent
+  }: PriceStatsParams,
+  { price, priceChange, high, low, volume, ath, athChange }: PriceStatFlags
+): void => {
+  const priceRes = `${name}: ${format(current_price)}`;
+  let priceChangeRes;
+  let volumeRes;
+  let highRes;
+  let lowRes;
+  let athRes;
+  let athChangeRes;
+
+  if (priceChange) {
+    priceChangeRes = `change (24H): ${percent24h.toFixed(2)}%`;
+  }
+
+  if (high) {
+    highRes = `high (24H): ${format(high_24h)}`;
+  }
+
+  if (low) {
+    lowRes = `low (24H): ${format(low_24h)}`;
+  }
+
+  if (volume) {
+    volumeRes = `volume (24H): ${format(total_volume)}`;
+  }
+
+  if (ath) {
+    athRes = `ATH: ${format(athPrice)}`;
+  }
+
+  if (athChange) {
+    athChangeRes = `ATH (%): ${athPercent.toFixed(2)}%`;
+  }
+
+  logSuccess(
+    [priceRes, priceChangeRes, volumeRes, highRes, lowRes, athRes, athChangeRes]
+      .filter(Boolean)
+      .join(' - ')
+  );
+};

--- a/src/actions/saveCoinData.ts
+++ b/src/actions/saveCoinData.ts
@@ -1,8 +1,8 @@
-import type { ExportData } from '../app';
 import { logError, logSuccess } from '../utils';
 import { CSVEXT, JSONEXT } from '../constants';
 import { parseAsync } from 'json2csv';
 import fs from 'fs';
+import type { ExportData } from '../constants';
 
 export const saveCoinData = async (
   options: string,

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,19 +1,8 @@
 import CoinGeckoAPI from '@crypto-coffee/coingecko-api';
 import { saveCoinData } from './actions/saveCoinData';
-import { logError, logSuccess, format } from './utils';
-
-export type ExportData = Record<string, string | number>;
-
-interface Flags {
-  price: string[];
-  priceChange: boolean;
-  volume: boolean;
-  high: boolean;
-  low: boolean;
-  ath: boolean;
-  athChange: boolean;
-  save: string;
-}
+import { logError } from './utils';
+import { priceStats } from './actions/priceStats';
+import type { ExportData, Flags } from './constants';
 
 export const app = async (action: string, flags: Record<string, unknown>) => {
   const { price, priceChange, volume, high, low, ath, athChange, save } =
@@ -45,38 +34,6 @@ export const app = async (action: string, flags: Record<string, unknown>) => {
       ath: athPrice,
       ath_change_percentage: athPercent
     } of result) {
-      const priceRes = `${name}: ${format(current_price)}`;
-      let priceChangeRes;
-      let volumeRes;
-      let highRes;
-      let lowRes;
-      let athRes;
-      let athChangeRes;
-
-      if (priceChange) {
-        priceChangeRes = `change (24H): ${percent24h.toFixed(2)}%`;
-      }
-
-      if (high) {
-        highRes = `high (24H): ${format(high_24h)}`;
-      }
-
-      if (low) {
-        lowRes = `low (24H): ${format(low_24h)}`;
-      }
-
-      if (volume) {
-        volumeRes = `volume (24H): ${format(total_volume)}`;
-      }
-
-      if (ath) {
-        athRes = `ATH: ${format(athPrice)}`;
-      }
-
-      if (athChange) {
-        athChangeRes = `ATH (%): ${athPercent.toFixed(2)}%`;
-      }
-
       exportCoinData.push({
         name,
         current_price,
@@ -88,18 +45,18 @@ export const app = async (action: string, flags: Record<string, unknown>) => {
         ath_change_percentage: athPercent
       });
 
-      logSuccess(
-        [
-          priceRes,
-          priceChangeRes,
-          volumeRes,
-          highRes,
-          lowRes,
-          athRes,
-          athChangeRes
-        ]
-          .filter(Boolean)
-          .join(' - ')
+      priceStats(
+        {
+          name,
+          current_price,
+          total_volume,
+          high_24h,
+          low_24h,
+          percent24h,
+          athPrice,
+          athPercent
+        },
+        { price, priceChange, high, low, volume, ath, athChange }
       );
     }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,17 @@
+/** contstants */
 export const JSONEXT = 'json';
 export const CSVEXT = 'csv';
+
+/** types */
+export type ExportData = Record<string, string | number>;
+
+export interface Flags {
+  price: string[];
+  priceChange: boolean;
+  volume: boolean;
+  high: boolean;
+  low: boolean;
+  ath: boolean;
+  athChange: boolean;
+  save: string;
+}


### PR DESCRIPTION
This PR refactors `app.ts` which includes the `--price` flag functionality. I have now added this block into `src/actions` to couple the functionality within a function and `app.ts` should only call `actions` (or any future things).


Closes issue: https://github.com/Zidious/crypto-cli/issues/37