### PR TITLE
chore: ensure project builds after `yarn install`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prebuild": "rimraf dist",
     "build": "tsc",
     "test": "mocha 'src/*.test.ts'",
-    "prepare": "npx husky install",
+    "prepare": "npx husky install && yarn build",
     "precommit": "lint-staged"
   },
   "engines": {


### PR DESCRIPTION
This PR ensures that we build after `yarn install` occurs 