### PR TITLE
ci: remove self-hosted runner for GHAs

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -5,7 +5,7 @@ on:
       - develop
 jobs:
   publish:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     env:
       INPUT_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: Node.js ${{ matrix.node-version }}
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     env:
       INPUT_TOKEN: ${{ secrets.NPM_TOKEN }}
     strategy:

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   publish:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     env:
       INPUT_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:


### PR DESCRIPTION
My Raspberry Pi is dying :( use GH runner instead of self-hosted