### PR TITLE
fix: adjust price formatting to account for meme coins

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,9 +14,9 @@ export const logSuccess = (message: string) => {
 
 export const format = (price: number) => {
   const decimalPart = price.toString().split('.')[1]
-  // If the decimal part starts with 0000, it's likely a meme coin
+  // If the decimal part starts with 000, it's likely a meme coin
   // and we want to show more decimal places to avoid showing 0.00
-  const isMemeCoin = decimalPart && decimalPart.slice(0, 4) === '0000'
+  const isMemeCoin = decimalPart && decimalPart.slice(0, 3) === '000'
 
   return new Intl.NumberFormat('en-US', {
     style: 'currency',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,11 +3,6 @@ import chalk from 'chalk'
 const ERROR = chalk.bold.red
 const SUCCESS = chalk.bold.green
 
-const formatter = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD'
-})
-
 export const logError = (message: string) => {
   console.error(ERROR(message))
   process.exit(1)
@@ -18,7 +13,16 @@ export const logSuccess = (message: string) => {
 }
 
 export const format = (price: number) => {
-  return formatter.format(price)
+  const decimalPart = price.toString().split('.')[1]
+  // If the decimal part starts with 0000, it's likely a meme coin
+  // and we want to show more decimal places to avoid showing 0.00
+  const isMemeCoin = decimalPart && decimalPart.slice(0, 4) === '0000'
+
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: isMemeCoin ? 10 : 2
+  }).format(price)
 }
 
 export const formatFileName = (coinName: string, fileExt: string): string => {


### PR DESCRIPTION
This patch amends the price formatting to account for meme coins, we'll now print the full price of the coin. 


closes: https://github.com/Zidious/crypto-cli/issues/70